### PR TITLE
Specify Action Tests GitHub Pages Build Capability in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Automated Validation](https://github.com/PaulRosenthal/Jekyll-Deploy-Test-Action/actions/workflows/automated-validation.yml/badge.svg?branch=main)](https://github.com/PaulRosenthal/Jekyll-Deploy-Test-Action/actions/workflows/automated-validation.yml)
 
-This GitHub action validates whether a Jekyll website contains the necessary configuration to successfully build. It is intended to be used in a continuous integration (CI) pipeline or as part of a testing process.
+This GitHub action validates whether a Jekyll website contains the necessary configuration to successfully build using [GitHub Pages](https://pages.github.com/). It is intended to be used in a continuous integration (CI) pipeline or as part of a testing process.
 
 ## Inputs
 


### PR DESCRIPTION
This pull request updates the `README.md` file to specify that the action tests the ability to build a Jekyll website using GitHub Pages.